### PR TITLE
fix(ci): use GITHUB_TOKEN for tag/commit push in publish-pypi workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -10,6 +10,10 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
@@ -34,6 +38,10 @@ jobs:
         run: |
           VERSION=$(grep '^version = ' pyproject.toml | head -1 | cut -d '"' -f2)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+      - name: Set up git for pushing
+        if: github.ref == 'refs/heads/main'
+        run: |
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
       - name: Create and push tag for new version
         if: github.ref == 'refs/heads/main'
         run: |
@@ -52,7 +60,4 @@ jobs:
           python -m build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        # No password needed! Uses OIDC trusted publisher 
-permissions:
-  contents: read
-  id-token: write
+        # No password needed! Uses OIDC trusted publisher


### PR DESCRIPTION
## StackHawk Pull Request

> Description here

<!-- share a quality (SFW) gif or photo, or before-and-after views -->
![replace me](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExcnF4c2E5andrZnRsdnlqMjB6cHIwejh4b3lvbWplZTA3dW42NjkwNSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3o6Mb5Cy5tZFkNLLLa/giphy.gif)

### Type of change

- [x] Code
- [ ] Documentation
- [ ] Release
- [ ] Other _(please explain)_

### Related Issues

<!-- automation will associate the issue with this PR when the issue slug is included in the branch name or request title -->
> [NGNRNG-XXX](https://stackhawk.atlassian.net/browse/NGNRNG-XXX)

### Code

- [ ] This PR has a descriptive title, attached issue id, and information useful to a reviewer
- [ ] The "Ready for Review" label attached to the PR, and reviewers have been informed
- [ ] All lint rules and tests related to the changed code pass locally

Did you add or update tests to cover this change?
- [ ] Yes
- [ ] No: _(please explain)_

### Documentation

- [ ] Documentation has been updated, with attention to spelling, grammar and clarity

### Release

- [ ] This software deployment has been communicated to the team
- [ ] Relevant changes are reflected in the product changelog
