### PR TITLE
ci: move GH_TOKEN permission check before git operations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,11 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
+      - name: Test GH_TOKEN permissions
+        run: |
+          curl -v -H "Authorization: token ${{ secrets.GH_TOKEN }}" \
+            https://api.github.com/repos/${{ github.repository }}
+        shell: bash
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,11 @@ jobs:
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
+      - name: Test GH_TOKEN permissions
+        run: |
+          curl -v -H "Authorization: token ${{ secrets.GH_TOKEN }}" \
+            https://api.github.com/repos/${{ github.repository }}
+        shell: bash
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -54,11 +59,6 @@ jobs:
       - name: Set up git for pushing
         run: |
           git remote set-url origin https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }}.git
-      - name: Test GH_TOKEN permissions
-        run: |
-          curl -v -H "Authorization: token ${{ secrets.GH_TOKEN }}" \
-            https://api.github.com/repos/${{ github.repository }}
-        shell: bash
       - name: Set git user for GitHub Actions bot
         run: |
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## StackHawk Pull Request

> Description here

<!-- share a quality (SFW) gif or photo, or before-and-after views -->
![replace me](giphy-url.gif)

### Type of change

- [x] Code
- [ ] Documentation
- [ ] Release
- [ ] Other _(please explain)_

### Related Issues

<!-- automation will associate the issue with this PR when the issue slug is included in the branch name or request title -->
> [NGNRNG-XXX](https://stackhawk.atlassian.net/browse/NGNRNG-XXX)

### Code

- [ ] This PR has a descriptive title, attached issue id, and information useful to a reviewer
- [ ] The "Ready for Review" label attached to the PR, and reviewers have been informed
- [ ] All lint rules and tests related to the changed code pass locally

Did you add or update tests to cover this change?
- [ ] Yes
- [ ] No: _(please explain)_

### Documentation

- [ ] Documentation has been updated, with attention to spelling, grammar and clarity

### Release

- [ ] This software deployment has been communicated to the team
- [ ] Relevant changes are reflected in the product changelog
