### PR TITLE
fix: remove unnecessary persist-credentials option from checkout steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,6 @@ jobs:
     needs: tag
     steps:
       - uses: actions/checkout@v4
-        with:
-          persist-credentials: 'false'
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -67,8 +65,6 @@ jobs:
     needs: tag
     steps:
       - uses: actions/checkout@v4
-        with:
-          persist-credentials: 'false'
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx


### PR DESCRIPTION
## StackHawk Pull Request

> Description here

<!-- share a quality (SFW) gif or photo, or before-and-after views -->
![replace me](giphy-url.gif)

### Type of change

- [x] Code
- [ ] Documentation
- [ ] Release
- [ ] Other _(please explain)_

### Related Issues

<!-- automation will associate the issue with this PR when the issue slug is included in the branch name or request title -->
> [NGNRNG-XXX](https://stackhawk.atlassian.net/browse/NGNRNG-XXX)

### Code

- [ ] This PR has a descriptive title, attached issue id, and information useful to a reviewer
- [ ] The "Ready for Review" label attached to the PR, and reviewers have been informed
- [ ] All lint rules and tests related to the changed code pass locally

Did you add or update tests to cover this change?
- [ ] Yes
- [ ] No: _(please explain)_

### Documentation

- [ ] Documentation has been updated, with attention to spelling, grammar and clarity

### Release

- [ ] This software deployment has been communicated to the team
- [ ] Relevant changes are reflected in the product changelog
