### PR TITLE
Fix registry name check

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,4 +348,4 @@ Workflows are designed to skip jobs if the latest commit is an automated version
 3. Click "Run workflow" and choose the desired bump type (minor or major).
 4. The workflow will handle the rest!
 
-[//]: # (mcp-name: stackhawk.com/stackhawk-mcp)
+[//]: # (mcp-name: com.stackhawk/*)


### PR DESCRIPTION
This comment is used by the Anthropic MCP Registry process to verify we own this project.